### PR TITLE
tbb gcc clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CTRACK is a powerful tool that can be seamlessly integrated into both developmen
 ## Features
 
 - Single header file
-- No dependencies
+- No dependencies (optional tbb for non msvc to use paralell result calculation) 
 - Easy to use (just 1 line per function you want to track)
 - Minimal overhead (can record tens of millions events per second)
 - Optimized for multi-threaded environments
@@ -168,6 +168,9 @@ CTRACK is a header-only library, which means you can start using it by simply in
 
 This method is straightforward and doesn't require any additional setup or build process.
 
+Note: If you are using a compiler which needs TBB for C++ standard parallel algorithms, you need to link to -ltbb. You can always fall back to sequential result calculation by setting
+CTRACK_DISABLE_EXECUTION_POLICY. The recording will be unchanged, but the printing/calculating of the stats will be a bit slower.
+
 ### 2. CMake Package
 
 For projects using CMake, CTRACK can be installed and used as a CMake package. This method provides better integration with your build system and makes it easier to manage dependencies.
@@ -190,6 +193,11 @@ To use CTRACK as a CMake package:
    find_package(CTRACK REQUIRED)
    target_link_libraries(your_target PRIVATE CTRACK::CTRACK)
    ```
+
+Note: If you are using a compiler which needs TBB for C++ standard parallel algorithms, you need to link to tbb. 
+  ```target_link_libraries( your_target PRIVATE  TBB::tbb )   ```
+You can always fall back to sequential result calculation by setting
+CTRACK_DISABLE_EXECUTION_POLICY. The recording will be unchanged, but the printing/calculating of the stats will be a bit slower.
 
 For more detailed examples of how to use CTRACK with CMake, please refer to the `examples` directory in the CTRACK repository.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,40 @@
+option(DISABLE_PAR "Disable parallel processing" OFF)
+if(NOT MSVC AND NOT DISABLE_PAR)
+        # For other compilers, check for TBB
+        find_package(TBB QUIET)
+        if(TBB_FOUND)
+            message(STATUS "TBB found. Enabling parallel execution.")    
+        else()
+            message(STATUS "TBB not found. Disabling parallel execution.")
+            set(DISABLE_PAR ON)
+        endif()
+elseif(DISABLE_PAR)
+        message(STATUS "DISABLE_PAR set. Disabling parallel execution.")
+endif()
+
+
+# Function to enable parallel execution on non msvc
+function(enable_parallel_execution target)
+    if(DISABLE_PAR)
+        target_compile_definitions(${target} PRIVATE CTRACK_DISABLE_EXECUTION_POLICY)
+    elseif(NOT MSVC)
+       target_link_libraries(${target} PRIVATE TBB::tbb)
+    endif()
+endfunction()
+
 # Create executables for each example
 add_executable(basic_singlethreaded basic_singlethreaded.cpp)
 add_executable(multithreaded_prime_counter multithreaded_prime_counter.cpp)
 add_executable(ctrack_overhead_test ctrack_overhead_test.cpp)
 add_executable(high_variance_pi_estimation high_variance_pi_estimation.cpp)
 add_executable(complex_multithreaded_puzzle complex_multithreaded_puzzle.cpp)
+
+#check for paralell 
+enable_parallel_execution(basic_singlethreaded)
+enable_parallel_execution(multithreaded_prime_counter)
+enable_parallel_execution(ctrack_overhead_test)
+enable_parallel_execution(high_variance_pi_estimation)
+enable_parallel_execution(complex_multithreaded_puzzle)
 
 # Link the ctrack library to each example
 target_link_libraries(basic_singlethreaded PRIVATE ctrack)


### PR DESCRIPTION
https://github.com/Compaile/ctrack/issues/3

Since not all compilers support parallel execution without linking to TBB, we add a flag to fall back to sequential calculation of the results.
The CMake in the example folder also shows how to link to TBB (also added it to the README as a note).
If a user is on a compiler which would need TBB for parallel execution but does not want to include TBB, we added a fallback with a sequential mode.