### PR TITLE
Patch 1 0 2 improve tbb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,24 @@
 cmake_minimum_required(VERSION 3.12)
-project(ctrack VERSION 1.0.0 LANGUAGES CXX)
+project(ctrack VERSION 1.0.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Option to disable parallel processing
+option(DISABLE_PAR "Disable parallel processing" OFF)
+
+# Check for TBB
+if(NOT MSVC AND NOT DISABLE_PAR)
+    find_package(TBB QUIET)
+    if(TBB_FOUND)
+        message(STATUS "TBB found. Enabling parallel execution.")
+    else()
+        message(STATUS "TBB not found. Disabling parallel execution.")
+        set(DISABLE_PAR ON)
+    endif()
+elseif(DISABLE_PAR)
+    message(STATUS "DISABLE_PAR set. Disabling parallel execution.")
+endif()
 
 # Create the ctrack library
 add_library(ctrack INTERFACE)
@@ -10,6 +26,13 @@ target_include_directories(ctrack INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+# Configure ctrack based on TBB availability
+if(DISABLE_PAR)
+    target_compile_definitions(ctrack INTERFACE CTRACK_DISABLE_EXECUTION_POLICY)
+elseif(NOT MSVC AND TBB_FOUND)
+    target_link_libraries(ctrack INTERFACE TBB::tbb)
+endif()
 
 # Add the examples subdirectory
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Option to disable parallel processing
 option(DISABLE_PAR "Disable parallel processing" OFF)
 
+# Option to disable building examples
+option(DISABLE_EXAMPLES "Disable building examples" OFF)
+
 # Check for TBB
 if(NOT MSVC AND NOT DISABLE_PAR)
     find_package(TBB QUIET)
@@ -34,8 +37,12 @@ elseif(NOT MSVC AND TBB_FOUND)
     target_link_libraries(ctrack INTERFACE TBB::tbb)
 endif()
 
-# Add the examples subdirectory
-add_subdirectory(examples)
+# Add the examples subdirectory if not disabled
+if(NOT DISABLE_EXAMPLES)
+    add_subdirectory(examples)
+else()
+    message(STATUS "Building examples disabled.")
+endif()
 
 # Installation
 include(GNUInstallDirs)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,3 +1,18 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/ctrackTargets.cmake")
+
+if(NOT MSVC AND NOT CTRACK_DISABLE_EXECUTION_POLICY)
+    include(CMakeFindDependencyMacro)
+    find_dependency(TBB QUIET)
+    if(NOT TBB_FOUND)
+        message(STATUS "TBB not found. Disabling parallel execution for ctrack.")
+        set(CTRACK_DISABLE_EXECUTION_POLICY ON)
+    endif()
+endif()
+
+if(CTRACK_DISABLE_EXECUTION_POLICY)
+    target_compile_definitions(ctrack::ctrack INTERFACE CTRACK_DISABLE_EXECUTION_POLICY)
+endif()
+
+check_required_components(ctrack)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,26 +1,3 @@
-option(DISABLE_PAR "Disable parallel processing" OFF)
-if(NOT MSVC AND NOT DISABLE_PAR)
-        # For other compilers, check for TBB
-        find_package(TBB QUIET)
-        if(TBB_FOUND)
-            message(STATUS "TBB found. Enabling parallel execution.")    
-        else()
-            message(STATUS "TBB not found. Disabling parallel execution.")
-            set(DISABLE_PAR ON)
-        endif()
-elseif(DISABLE_PAR)
-        message(STATUS "DISABLE_PAR set. Disabling parallel execution.")
-endif()
-
-
-# Function to enable parallel execution on non msvc
-function(enable_parallel_execution target)
-    if(DISABLE_PAR)
-        target_compile_definitions(${target} PRIVATE CTRACK_DISABLE_EXECUTION_POLICY)
-    elseif(NOT MSVC)
-       target_link_libraries(${target} PRIVATE TBB::tbb)
-    endif()
-endfunction()
 
 # Create executables for each example
 add_executable(basic_singlethreaded basic_singlethreaded.cpp)
@@ -28,13 +5,6 @@ add_executable(multithreaded_prime_counter multithreaded_prime_counter.cpp)
 add_executable(ctrack_overhead_test ctrack_overhead_test.cpp)
 add_executable(high_variance_pi_estimation high_variance_pi_estimation.cpp)
 add_executable(complex_multithreaded_puzzle complex_multithreaded_puzzle.cpp)
-
-#check for paralell 
-enable_parallel_execution(basic_singlethreaded)
-enable_parallel_execution(multithreaded_prime_counter)
-enable_parallel_execution(ctrack_overhead_test)
-enable_parallel_execution(high_variance_pi_estimation)
-enable_parallel_execution(complex_multithreaded_puzzle)
 
 # Link the ctrack library to each example
 target_link_libraries(basic_singlethreaded PRIVATE ctrack)

--- a/include/ctrack.hpp
+++ b/include/ctrack.hpp
@@ -30,7 +30,7 @@
 
 #define CTRACK_VERSION_MAJOR 1
 #define CTRACK_VERSION_MINOR 0
-#define CTRACK_VERSION_PATCH 1
+#define CTRACK_VERSION_PATCH 2
 
 // Helper macro to convert a numeric value to a string
 #define STRINGIFY(x) #x


### PR DESCRIPTION
fixes https://github.com/Compaile/ctrack/issues/3

- does not require a user anymore to manually set flags for tbb when using ctrack as a cmake package
- added option to disable examples
- bump version to 1 0 2