### PR TITLE
Fix warnings to allow using the header on pedantic projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ option(DISABLE_PAR "Disable parallel processing" OFF)
 # Option to disable building examples
 option(DISABLE_EXAMPLES "Disable building examples" OFF)
 
+option(ENABLE_WARNINGS "Enable warnings" OFF)
+
 # Check for TBB
 if(NOT MSVC AND NOT DISABLE_PAR)
     find_package(TBB QUIET)
@@ -25,7 +27,7 @@ endif()
 
 # Create the ctrack library
 add_library(ctrack INTERFACE)
-target_include_directories(ctrack INTERFACE 
+target_include_directories(ctrack INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
@@ -35,6 +37,14 @@ if(DISABLE_PAR)
     target_compile_definitions(ctrack INTERFACE CTRACK_DISABLE_EXECUTION_POLICY)
 elseif(NOT MSVC AND TBB_FOUND)
     target_link_libraries(ctrack INTERFACE TBB::tbb)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+if(ENABLE_WARNINGS)
+    if (NOT MSVC)
+        include(cmake/add_warning.cmake)
+        include(cmake/warnings.cmake)
+    endif()
 endif()
 
 # Add the examples subdirectory if not disabled

--- a/cmake/add_warning.cmake
+++ b/cmake/add_warning.cmake
@@ -1,0 +1,42 @@
+# Taken from https://github.com/ClickHouse/ClickHouse/blob/master/cmake/add_warnings.cmake
+
+include (CheckCXXCompilerFlag)
+
+# Try to add -Wflag if compiler supports it
+macro (add_warning flag)
+    string (REPLACE "-" "_" underscored_flag ${flag})
+    string (REPLACE "+" "x" underscored_flag ${underscored_flag})
+
+    check_cxx_compiler_flag("-W${flag}" SUPPORTS_CXXFLAG_${underscored_flag})
+
+    if (SUPPORTS_CXXFLAG_${underscored_flag})
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W${flag}")
+    else ()
+        message (STATUS "Flag -W${flag} is unsupported")
+    endif ()
+
+endmacro ()
+
+# Try to add -Wno flag if compiler supports it
+macro (no_warning flag)
+    add_warning(no-${flag})
+endmacro ()
+
+
+# The same but only for specified target.
+macro (target_add_warning target flag)
+    string (REPLACE "-" "_" underscored_flag ${flag})
+    string (REPLACE "+" "x" underscored_flag ${underscored_flag})
+
+    check_cxx_compiler_flag("-W${flag}" SUPPORTS_CXXFLAG_${underscored_flag})
+
+    if (SUPPORTS_CXXFLAG_${underscored_flag})
+        target_compile_options (${target} PRIVATE "-W${flag}")
+    else ()
+        message (STATUS "Flag -W${flag} is unsupported")
+    endif ()
+endmacro ()
+
+macro (target_no_warning target flag)
+    target_add_warning(${target} no-${flag})
+endmacro ()

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,0 +1,46 @@
+# Taken from https://github.com/ClickHouse/ClickHouse/blob/master/cmake/warnings.cmake,
+# slightly modified to fit into ctrack style.
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+# Control maximum size of stack frames. It can be important if the code is run in fibers with small stack size.
+# Only in release build because debug has too large stack frames.
+if ((NOT CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG") AND (NOT SANITIZE) AND (NOT CMAKE_CXX_COMPILER_ID MATCHES "AppleClang"))
+    add_warning(frame-larger-than=65536)
+endif ()
+
+# Add some warnings that are not available even with -Wall -Wextra -Wpedantic.
+# We want to get everything out of the compiler for code quality.
+add_warning(everything)
+add_warning(pedantic)
+no_warning(zero-length-array)
+no_warning(c++98-compat-pedantic)
+no_warning(c++98-compat)
+no_warning(c++20-compat) # Use constinit in C++20 without warnings
+no_warning(sign-conversion)
+no_warning(implicit-int-conversion)
+no_warning(implicit-int-float-conversion)
+no_warning(ctad-maybe-unsupported) # clang 9+, linux-only
+no_warning(disabled-macro-expansion)
+no_warning(documentation-unknown-command)
+no_warning(double-promotion)
+no_warning(exit-time-destructors)
+no_warning(float-equal)
+no_warning(global-constructors)
+no_warning(missing-prototypes)
+no_warning(missing-variable-declarations)
+no_warning(padded)
+no_warning(switch-enum)
+no_warning(undefined-func-template)
+no_warning(unused-template)
+no_warning(vla)
+no_warning(weak-template-vtables)
+no_warning(weak-vtables)
+no_warning(thread-safety-negative) # experimental flag, too many false positives
+no_warning(enum-constexpr-conversion) # breaks magic-enum library in clang-16
+no_warning(unsafe-buffer-usage) # too aggressive
+no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
+
+# Styling decisions for ctrack
+no_warning(shadow-field-in-constructor)
+no_warning(newline-eof)


### PR DESCRIPTION
Some projects have strict requirements regarding warnings. Let's have an option to enable pedantic warnings and address them to allow those projects to use the header without having to disable them manually.

e.g. for ClickHouse

```c++
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wall"
#pragma clang diagnostic ignored "-Wextra"
#pragma clang diagnostic ignored "-Weverything"
#pragma clang diagnostic ignored "-Wpedantic"
#define CTRACK_DISABLE_EXECUTION_POLICY 1
#include "ctrack.hpp"
#pragma clang diagnostic pop
```

I've disabled some warnings compared to the ones we use at ClickHouse because they were too many and could be a style decision: `shadow-field-in-constructor` and `newline-eof`.